### PR TITLE
Update to support xz compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG AIMMS_VERSION_MAJOR
 ARG AIMMS_VERSION_MINOR
 
 RUN apt-get update && \
-    apt-get install -y locales unixodbc wget gcc dos2unix && \
+    apt-get install -y locales unixodbc wget gcc dos2unix xz-utils && \
     rm -rf /var/lib/apt/lists/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8


### PR DESCRIPTION
The latest version of AIMMS has changes on compression and xz-utils is required before AIMMS installer is executed on ubuntu.